### PR TITLE
Kinetic: minimal changes for compiling on ROS Kinetic (#5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,26 @@ project(agile_grasp)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS cmake_modules cv_bridge eigen_conversions geometry_msgs 
-message_generation pcl_conversions roscpp sensor_msgs std_msgs visualization_msgs)
+find_package(catkin REQUIRED COMPONENTS eigen_conversions geometry_msgs
+message_generation pcl_conversions roscpp sensor_msgs std_msgs visualization_msgs tf_conversions)
+
+# Special handling for Eigen, which is different between Indigo and Jade/Kinetic.
+# This should work for both:
+#   http://wiki.ros.org/jade/Migration#Eigen_CMake_Module_in_cmake_modules
+find_package(Eigen3)
+if(NOT EIGEN3_FOUND)
+  # Fallback to cmake_modules
+  find_package(cmake_modules REQUIRED)
+  find_package(Eigen REQUIRED)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
+else()
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+endif()
+
 
 ## System dependencies are found with CMake's conventions
-find_package(Eigen REQUIRED)
 find_package(LAPACK REQUIRED)
-find_package(OpenCV)
+find_package(OpenCV 2 REQUIRED)
 find_package(PCL REQUIRED)
 #~ find_package(VTK 6.0 REQUIRED NO_MODULE) # required in Fedora Core
 
@@ -83,7 +96,6 @@ catkin_package(
   hand_search
  CATKIN_DEPENDS
 	cmake_modules
-	cv_bridge
   eigen_conversions 
   geometry_msgs 
   message_runtime 
@@ -93,7 +105,6 @@ catkin_package(
   std_msgs
   visualization_msgs
  DEPENDS 
-  Eigen
   LAPACK
   OpenCV
   PCL  
@@ -105,7 +116,11 @@ catkin_package(
 
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
-include_directories(include ${catkin_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
+include_directories(include
+  ${catkin_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
+  ${PCL_INCLUDE_DIRS}
+  ${OpenCV_INCLUDE_DIRS})
 #~ include(${VTK_USE_FILE}) # required in Fedora Core
 
 ## Declare a cpp library

--- a/package.xml
+++ b/package.xml
@@ -12,10 +12,10 @@
   <buildtool_depend>catkin</buildtool_depend>
  
 	<build_depend>cmake_modules</build_depend>
-	<build_depend>cv_bridge</build_depend>
   <build_depend>eigen_conversions</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>liblapack-dev</build_depend>
+  <build_depend>libopencv-dev</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>message_generation</build_depend>   
   <build_depend>roscpp</build_depend>
@@ -25,10 +25,10 @@
   <build_depend>visualization_msgs</build_depend>  
   
   <run_depend>cmake_modules</run_depend>
-  <run_depend>cv_bridge</run_depend>
   <run_depend>eigen_conversions</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>liblapack-dev</run_depend>
+  <run_depend>libopencv-dev</run_depend>
   <run_depend>libpcl-all</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>pcl_conversions</run_depend>


### PR DESCRIPTION
Migration from Indigo Eigen interface
Force use of OpenCV2 interfaces
Add explicit dependency on libopencv-dev,
  replacing the cv_bridge dependency needed for Indigo.

* These changes should *not* be merged into ``master``, they will break the Indigo version. I'd recommend creating a ``kinetic`` branch, and merging them there.

 * It builds, but with some ugly compiler warnings about deprecated Eigen interfaces.

 * It runs the opencv_test, displaying a black window with two white dots. I lack the means and expertise for more testing.